### PR TITLE
Develop

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".core.services.quake.NetworkQuakeService"
+            android:enabled="true"
+            android:exported="false" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/modelomatematico/smarthome/core/constants/AppStrings.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/core/constants/AppStrings.kt
@@ -7,4 +7,8 @@ object AppStrings {
     const val SUCCESS = "Exito"
     const val WARNING = "Advertencia"
 
+
+    const val ACTION_START_QUEUE_SERVICE = "startQueueService"
+    const val ACTION_STOP_QUEUE_SERVICE = "stopQueueService"
+
 }

--- a/app/src/main/java/com/modelomatematico/smarthome/core/services/empty.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/core/services/empty.kt
@@ -1,0 +1,2 @@
+package com.modelomatematico.smarthome.core.services
+

--- a/app/src/main/java/com/modelomatematico/smarthome/core/services/quake/NetworkQuakeService.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/core/services/quake/NetworkQuakeService.kt
@@ -1,0 +1,28 @@
+package com.modelomatematico.smarthome.core.services.quake
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import com.modelomatematico.smarthome.core.constants.AppStrings
+
+class NetworkQuakeService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent != null) {
+            val action = intent.action
+            action?.let { currentAction ->
+                when (currentAction) {
+                    AppStrings.ACTION_START_QUEUE_SERVICE -> startSensorQueue()
+                    AppStrings.ACTION_STOP_QUEUE_SERVICE -> stopSelf()
+                }
+            }
+        }
+        return START_STICKY
+    }
+
+    private fun startSensorQueue() {
+        Log.i("NetworkQuakeService", "Starting sensor queue")
+    }
+}

--- a/app/src/main/java/com/modelomatematico/smarthome/core/task/TaskNetworkQuakeService.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/core/task/TaskNetworkQuakeService.kt
@@ -1,0 +1,38 @@
+package com.modelomatematico.smarthome.core.task
+
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import com.modelomatematico.smarthome.core.constants.AppStrings
+import com.modelomatematico.smarthome.core.services.quake.NetworkQuakeService
+
+class TaskNetworkQuakeService {
+
+    private fun isServiceRunning(context: Context): Boolean {
+        val activityManager =
+            context.getSystemService(AppCompatActivity.ACTIVITY_SERVICE) as ActivityManager
+        for (service in activityManager.getRunningServices(Int.MAX_VALUE)) {
+            if (NetworkQuakeService::class.java.name == service.service.className) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fun startService(context: Context) {
+        if (!isServiceRunning(context)) {
+            val intent = Intent(context, NetworkQuakeService::class.java).apply {
+                action = AppStrings.ACTION_START_QUEUE_SERVICE
+            }
+            context.startService(intent)
+        }
+    }
+
+    fun stopService(context: Context) {
+        if (isServiceRunning(context)) {
+            val intent = Intent(context, NetworkQuakeService::class.java)
+            context.stopService(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/ControlButtonsActivity.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/ControlButtonsActivity.kt
@@ -1,4 +1,5 @@
 package com.modelomatematico.smarthome.features.home.view.ui
+
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
@@ -7,8 +8,11 @@ import androidx.cardview.widget.CardView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.modelomatematico.smarthome.R
+import com.modelomatematico.smarthome.core.task.TaskNetworkQuakeService
 
 class ControlButtonsActivity : AppCompatActivity() {
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -44,5 +48,11 @@ class ControlButtonsActivity : AppCompatActivity() {
             Toast.makeText(this, "Control de comedor", Toast.LENGTH_SHORT).show()
             // Aquí puedes agregar la lógica para el comedor
         }
+
+        startNetworkQuakeService()
+    }
+
+    private fun startNetworkQuakeService() {
+        TaskNetworkQuakeService().startService(this)
     }
 }


### PR DESCRIPTION
This pull request introduces a new `NetworkQuakeService` to manage a sensor queue and integrates it into the application. Key changes include adding the service definition, creating utility methods for starting and stopping the service, and updating the `ControlButtonsActivity` to start the service. Below is a breakdown of the most important changes:

### Service Implementation and Configuration:

* Added a new `NetworkQuakeService` class in `core/services/quake/NetworkQuakeService.kt` to handle service lifecycle and manage sensor queue operations. The service processes `ACTION_START_QUEUE_SERVICE` and `ACTION_STOP_QUEUE_SERVICE` intents.
* Declared the `NetworkQuakeService` in the `AndroidManifest.xml` file with `android:enabled="true"` and `android:exported="false"`.

### Utility for Service Management:

* Introduced a `TaskNetworkQuakeService` class in `core/task/TaskNetworkQuakeService.kt` to provide utility methods for checking if the service is running, and for starting or stopping the service.

### Constants Update:

* Added `ACTION_START_QUEUE_SERVICE` and `ACTION_STOP_QUEUE_SERVICE` constants to `AppStrings` in `core/constants/AppStrings.kt` for intent actions.

### Integration with UI:

* Updated `ControlButtonsActivity` in `features/home/view/ui/ControlButtonsActivity.kt` to start the `NetworkQuakeService` by calling `TaskNetworkQuakeService().startService(this)` during initialization.