### PR TITLE
feat(home): :sparkles: update HomeActivity and HomeCardAdapter for im…

### DIFF
--- a/app/src/main/java/com/modelomatematico/smarthome/core/services/quake/NetworkQuakeService.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/core/services/quake/NetworkQuakeService.kt
@@ -18,11 +18,13 @@ class NetworkQuakeService : Service() {
                     AppStrings.ACTION_STOP_QUEUE_SERVICE -> stopSelf()
                 }
             }
-        }
+            }
         return START_STICKY
     }
 
     private fun startSensorQueue() {
+//        TODO: Implement the logic to start the sensor queue
         Log.i("NetworkQuakeService", "Starting sensor queue")
     }
+
 }

--- a/app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/HomeActivity.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/HomeActivity.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.modelomatematico.smarthome.R
 import com.modelomatematico.smarthome.core.task.TaskNetworkQuakeService
 import com.modelomatematico.smarthome.databinding.ActivityControlButtonsBinding
-import com.modelomatematico.smarthome.features.home.view.adapter.HomeCardAdapter
+import com.modelomatematico.smarthome.features.home.view.ui.adapter.HomeCardAdapter
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -32,15 +32,14 @@ class HomeActivity : AppCompatActivity() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
+        cardTitles = resources.getStringArray(R.array.home_card_titles).toList()
+        cardActions = resources.getStringArray(R.array.home_card_actions)
 
         initRecyclerView()
         startNetworkQuakeService()
     }
 
     private fun initRecyclerView() {
-        cardTitles = resources.getStringArray(R.array.home_card_titles).toList()
-        cardActions = resources.getStringArray(R.array.home_card_actions)
-
         binding.rvHomeCards.layoutManager = GridLayoutManager(this, 2)
         binding.rvHomeCards.adapter = HomeCardAdapter(cardTitles) { cardTitle ->
             handleCardClick(cardTitle)

--- a/app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/adapter/HomeCardAdapter.kt
+++ b/app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/adapter/HomeCardAdapter.kt
@@ -1,13 +1,12 @@
-package com.modelomatematico.smarthome.features.home.view.adapter
+package com.modelomatematico.smarthome.features.home.view.ui.adapter
 
-import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.graphics.toColorInt
 import androidx.recyclerview.widget.RecyclerView
 import com.modelomatematico.smarthome.R
 import com.modelomatematico.smarthome.databinding.ItemHomeCardBinding
-import androidx.core.graphics.toColorInt
 
 class HomeCardAdapter(
     private val cardTitles: List<String>,
@@ -60,16 +59,13 @@ class HomeCardViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     }
 
     fun render(cardTitle: String, position: Int) {
-        // Configurar textos
         binding.tvTitle.text = cardTitle
         binding.tvSubtitle.text = subtitles[position]
 
-        // Configurar colores
         binding.cardView.setCardBackgroundColor(backgrounds[position].toColorInt())
         binding.tvTitle.setTextColor(textColors[position].toColorInt())
         binding.tvSubtitle.setTextColor(subtitleColors[position].toColorInt())
 
-        // Configurar icono
         val iconResource = cardIconMap[cardTitle.uppercase()]
         iconResource?.let {
             binding.ivIcon.setImageResource(it)


### PR DESCRIPTION
This pull request includes several changes aimed at improving code organization, readability, and functionality in the `NetworkQuakeService`, `HomeActivity`, and `HomeCardAdapter` components. The key updates involve refactoring imports and package names, relocating initialization logic for better structure, and cleaning up unused comments in the code.

### Code organization and refactoring:

* **Refactored package name for `HomeCardAdapter`:** The `HomeCardAdapter` class was moved from `features.home.view.adapter` to `features.home.view.ui.adapter` to align with the updated project structure. Corresponding import statements in `HomeActivity` were updated. (`[[1]](diffhunk://#diff-7c83d36927efe1020dab29357d675c9f30430142a479dc671c2ad762aa12a23aL1-L10)`, `[[2]](diffhunk://#diff-666e3c6e0b366bfae057a009389b90c4538251c75b751447c8ece31bd778dabeL13-R13)`)

### Code readability and cleanup:

* **Removed redundant comments in `HomeCardViewHolder`:** Unnecessary comments describing basic configuration steps (e.g., setting text, colors, and icons) were removed to make the code cleaner and more concise. (`[app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/adapter/HomeCardAdapter.ktL63-L72](diffhunk://#diff-7c83d36927efe1020dab29357d675c9f30430142a479dc671c2ad762aa12a23aL63-L72)`)
* **Added a TODO in `NetworkQuakeService`:** A placeholder comment was added in the `startSensorQueue` method to indicate that implementation logic needs to be added in the future. (`[app/src/main/java/com/modelomatematico/smarthome/core/services/quake/NetworkQuakeService.ktR26-R29](diffhunk://#diff-0cc9861baa88b4a0c95024493eb63abe5c945aa5eaa0bc35efcb4888aff4fdd2R26-R29)`)

### Functional improvements:

* **Relocated initialization logic in `HomeActivity`:** The initialization of `cardTitles` and `cardActions` was moved from the `initRecyclerView` method to the `onCreate` method to ensure these resources are prepared earlier in the activity lifecycle. (`[app/src/main/java/com/modelomatematico/smarthome/features/home/view/ui/HomeActivity.ktR35-L43](diffhunk://#diff-666e3c6e0b366bfae057a009389b90c4538251c75b751447c8ece31bd778dabeR35-L43)`)…proved UI structure and organization